### PR TITLE
ukrywanie nieaktywnych graczy

### DIFF
--- a/db.php
+++ b/db.php
@@ -6,6 +6,17 @@ function checkPassword($pass) {
 
 function getRanking($con) {
 	$result = mysqli_query($con, "SELECT imie, nazwisko, punkty, meczy, wygranych FROM gracze "
+                . " ORDER BY punkty DESC, wygranych/meczy DESC");
+	$ranking = array();
+                 
+	while ($row = mysqli_fetch_array($result)) {
+		$ranking[] = $row;
+	}
+	return $ranking;
+}
+
+function getRankingForActivePlayers($con) {
+	$result = mysqli_query($con, "SELECT imie, nazwisko, punkty, meczy, wygranych FROM gracze "
                 . " WHERE DATE_SUB(NOW(), INTERVAL 60 DAY) < (select  max(data) from mecze where a like nazwisko OR b like nazwisko OR c like nazwisko OR d like nazwisko)   ORDER BY punkty DESC, wygranych/meczy DESC");
 	$ranking = array();
                  

--- a/db.php
+++ b/db.php
@@ -5,8 +5,10 @@ function checkPassword($pass) {
 }
 
 function getRanking($con) {
-	$result = mysqli_query($con, "SELECT imie, nazwisko, punkty, meczy, wygranych FROM gracze ORDER BY punkty DESC, wygranych/meczy DESC");
+	$result = mysqli_query($con, "SELECT imie, nazwisko, punkty, meczy, wygranych FROM gracze "
+                . " WHERE DATE_SUB(NOW(), INTERVAL 60 DAY) < (select  max(data) from mecze where a like nazwisko OR b like nazwisko OR c like nazwisko OR d like nazwisko)   ORDER BY punkty DESC, wygranych/meczy DESC");
 	$ranking = array();
+                 
 	while ($row = mysqli_fetch_array($result)) {
 		$ranking[] = $row;
 	}
@@ -29,7 +31,7 @@ function getSortedSurnames($ranking) {
 	$surnames = array();
 	foreach ($ranking as $row)
 		$surnames[] = $row['nazwisko'];
-	usort($surnames, sort_m);
+	usort($surnames, "sort_m");
 	return $surnames;
 }
 

--- a/index.php
+++ b/index.php
@@ -12,8 +12,14 @@ if (isset($_REQUEST['pass'])) {
 	}
 }
 
-$ranking = getRanking($con);
-$surnames = getSortedSurnames($ranking);
+$allPlayers = false;
+if( isset($_REQUEST['allPlayers'])){
+    $allPlayers = ($_REQUEST['allPlayers'] === "true")?true:false;
+    $ranking = ($_REQUEST['allPlayers'] === "true")?getRanking($con):getRankingForActivePlayers($con);    
+} else {
+    $ranking = getRankingForActivePlayers($con);    
+}
+ 
 $matches = getMatches($con);
 $total_matches = getTotalMatches($con);
 
@@ -83,7 +89,14 @@ require 'header.php';
 
 <div class="jumbotron">
 	<h3>Ranking </h3>
-	<h6>(na podstawie <?php echo $total_matches; ?> meczy)</h6>
+        <h6>(<?php
+            if (!$allPlayers){
+             echo "<a href=\"index.php?allPlayers=true\">aktywnych zawodników</a>";
+            }else{
+              echo "<a href=\"index.php?allPlayers=false\">wszystkich zawodników</a>";  
+            }
+            ?>
+            na podstawie <?php echo $total_matches; ?> meczy)</h6>
 	
 	<table class="table table-striped text-left">
 		<thead>


### PR DESCRIPTION
No dodałem przełącznik aktywni/nieaktywni. Wydaje mi się, że lepiej by domyślnie pokazywali się tylko aktywni gracze.

Trochę poszedłem na łatwiznę i po prostu dodałem nową funkcję ściągającą graczy z bazy, która jest wołana tylko z index.php. We wszystkich innych przypadkach jest używana stara funkcja, przez co nie musiałem poprawiać innych jej użyć.